### PR TITLE
Feat(BILL-PCI48): Improve Api Gateway Testing

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.8"
 }
 
 jacocoTestReport {

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClient.java
@@ -13,7 +13,12 @@ import reactor.core.publisher.Mono;
 public class BillServiceClient {
 
     private final WebClient.Builder webClientBuilder;
-    private final String billServiceUrl;
+
+    public void setBillServiceUrl(String billServiceUrl) {
+        this.billServiceUrl = billServiceUrl;
+    }
+
+    private String billServiceUrl;
 
 
     public BillServiceClient(

--- a/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/BillDetails.java
+++ b/api-gateway/src/main/java/com/petclinic/bffapigateway/dtos/BillDetails.java
@@ -1,11 +1,15 @@
 package com.petclinic.bffapigateway.dtos;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 
 
-@Data
+@Setter
+@Getter
+@NoArgsConstructor
 public class BillDetails {
     private int billId;
     private Date date;

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
@@ -107,18 +107,77 @@ class BillServiceClientTest {
 
     @Test
     void getBillsByVetId() {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("[{\n" +
+                        "        \"billId\": 63701,\n" +
+                        "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                        "        \"customerId\": 1,\n" +
+                        "        \"vetId\": 2,\n" +
+                        "        \"petId\": 2,\n" +
+                        "        \"visitType\": \"Examinations\",\n" +
+                        "        \"amount\": 59.99\n" +
+                        "    }]"));
+
+        Flux<BillDetails> billDetailsFlux = billServiceClient.getBillsByVetId(2);
+
+        assertEquals(63701, billDetailsFlux.blockFirst().getBillId());
     }
 
     @Test
     void getBillsByPetId() {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("[{\n" +
+                        "        \"billId\": 63701,\n" +
+                        "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                        "        \"customerId\": 1,\n" +
+                        "        \"vetId\": 2,\n" +
+                        "        \"petId\": 2,\n" +
+                        "        \"visitType\": \"Examinations\",\n" +
+                        "        \"amount\": 59.99\n" +
+                        "    }]"));
+
+        Flux<BillDetails> billDetailsFlux = billServiceClient.getBillsByPetId(2);
+
+        assertEquals(63701, billDetailsFlux.blockFirst().getBillId());
     }
 
     @Test
     void getBillsByCustomerId() {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("[{\n" +
+                        "        \"billId\": 63701,\n" +
+                        "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                        "        \"customerId\": 1,\n" +
+                        "        \"vetId\": 2,\n" +
+                        "        \"petId\": 2,\n" +
+                        "        \"visitType\": \"Examinations\",\n" +
+                        "        \"amount\": 59.99\n" +
+                        "    }]"));
+
+        Flux<BillDetails> billDetailsFlux = billServiceClient.getBillsByCustomerId(1);
+
+        assertEquals(63701, billDetailsFlux.blockFirst().getBillId());
     }
 
     @Test
     void deleteBill() {
+        prepareResponse(response -> response
+            .setHeader("Content-Type", "application/json")
+            .setBody("{\n" +
+                    "        \"billId\": 63701,\n" +
+                    "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                    "        \"customerId\": 1,\n" +
+                    "        \"vetId\": 2,\n" +
+                    "        \"petId\": 2,\n" +
+                    "        \"visitType\": \"Examinations\",\n" +
+                    "        \"amount\": 59.99\n" +
+                    "    }"));
+
+        Mono<Void> empty = billServiceClient.deleteBill(1);
+        assertEquals(empty.block(), null);
     }
 
     private void prepareResponse(Consumer<MockResponse> consumer) {

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
@@ -1,12 +1,63 @@
 package com.petclinic.bffapigateway.domainclientlayer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petclinic.bffapigateway.dtos.BillDetails;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 class BillServiceClientTest {
 
+    private BillServiceClient billServiceClient;
+
+    private MockWebServer server;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        server = new MockWebServer();
+        billServiceClient = new BillServiceClient(
+                WebClient.builder(),
+                "bills-service",
+                "7000"
+        );
+        billServiceClient.setBillServiceUrl(server.url("/").toString());
+        objectMapper = new ObjectMapper();
+    }
+
+    @AfterEach
+    void shutdown() throws IOException {
+        this.server.shutdown();
+    }
+
     @Test
     void getBilling() {
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\n" +
+                        "        \"billId\": 63701,\n" +
+                        "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                        "        \"customerId\": 1,\n" +
+                        "        \"vetId\": 2,\n" +
+                        "        \"petId\": 2,\n" +
+                        "        \"visitType\": \"Examinations\",\n" +
+                        "        \"amount\": 59.99\n" +
+                        "    }"));
+
+        Mono<BillDetails> billDetailsMono = billServiceClient.getBilling(63701);
+
+        assertEquals(63701, billDetailsMono.block().getBillId());
     }
 
     @Test
@@ -32,4 +83,11 @@ class BillServiceClientTest {
     @Test
     void deleteBill() {
     }
+
+    private void prepareResponse(Consumer<MockResponse> consumer) {
+        MockResponse response = new MockResponse();
+        consumer.accept(response);
+        this.server.enqueue(response);
+    }
+
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -62,6 +63,21 @@ class BillServiceClientTest {
 
     @Test
     void getAllBilling() {
+        prepareResponse(response -> response
+            .setHeader("Content-Type", "application/json")
+            .setBody("[{\n" +
+                    "        \"billId\": 63701,\n" +
+                    "        \"date\": \"2022-10-09T03:29:52.992+00:00\",\n" +
+                    "        \"customerId\": 1,\n" +
+                    "        \"vetId\": 2,\n" +
+                    "        \"petId\": 2,\n" +
+                    "        \"visitType\": \"Examinations\",\n" +
+                    "        \"amount\": 59.99\n" +
+                    "    }]"));
+
+        Flux<BillDetails> billDetailsFlux = billServiceClient.getAllBilling();
+
+        assertEquals(63701, billDetailsFlux.blockFirst().getBillId());
     }
 
     @Test

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
@@ -1,0 +1,35 @@
+package com.petclinic.bffapigateway.domainclientlayer;
+
+import org.junit.jupiter.api.Test;
+
+
+class BillServiceClientTest {
+
+    @Test
+    void getBilling() {
+    }
+
+    @Test
+    void getAllBilling() {
+    }
+
+    @Test
+    void createBill() {
+    }
+
+    @Test
+    void getBillsByVetId() {
+    }
+
+    @Test
+    void getBillsByPetId() {
+    }
+
+    @Test
+    void getBillsByCustomerId() {
+    }
+
+    @Test
+    void deleteBill() {
+    }
+}

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/domainclientlayer/BillServiceClientTest.java
@@ -1,5 +1,6 @@
 package com.petclinic.bffapigateway.domainclientlayer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.petclinic.bffapigateway.dtos.BillDetails;
 import okhttp3.mockwebserver.MockResponse;
@@ -81,7 +82,27 @@ class BillServiceClientTest {
     }
 
     @Test
-    void createBill() {
+    void createBill() throws JsonProcessingException {
+        BillDetails entity = new BillDetails();
+
+        entity.setBillId(1);
+
+        entity.setAmount(599);
+
+        entity.setCustomerId(2);
+
+        entity.setVetId(1);
+        entity.setPetId(1);
+
+        final String body = objectMapper.writeValueAsString(objectMapper.convertValue(entity, BillDetails.class));
+
+        prepareResponse(response -> response
+                .setHeader("Content-Type", "application/json")
+                .setBody(body));
+
+        Mono<BillDetails> billDetailsMono = billServiceClient.createBill(entity);
+
+        assertEquals(1, billDetailsMono.block().getBillId());
     }
 
     @Test

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -1405,4 +1405,33 @@ class ApiGatewayControllerTest {
                 .expectBody()
                 .jsonPath("$[0].billId").doesNotExist();
     }
+
+    @Test
+    void getAllBillings(){
+        BillDetails entity = new BillDetails();
+
+        entity.setBillId(1);
+
+        entity.setAmount(599);
+
+        entity.setCustomerId(2);
+
+        entity.setVetId(1);
+        entity.setPetId(1);
+
+        entity.setVisitType("Consultation");
+        when(billServiceClient.getAllBilling()).thenReturn(Flux.just(entity));
+        client.get()
+                //check the URI
+                .uri("/api/gateway/bills")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].billId").isEqualTo(1)
+                .jsonPath("$[0].customerId").isEqualTo(entity.getCustomerId())
+                .jsonPath("$[0].visitType").isEqualTo(entity.getVisitType())
+                .jsonPath("$[0].amount").isEqualTo(entity.getAmount())
+                .jsonPath("$[0].vetId").isEqualTo(entity.getVetId())
+                .jsonPath("$[0].petId").isEqualTo(entity.getPetId());
+    }
 }

--- a/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
+++ b/api-gateway/src/test/java/com/petclinic/bffapigateway/presentationlayer/ApiGatewayControllerTest.java
@@ -1434,4 +1434,17 @@ class ApiGatewayControllerTest {
                 .jsonPath("$[0].vetId").isEqualTo(entity.getVetId())
                 .jsonPath("$[0].petId").isEqualTo(entity.getPetId());
     }
+
+    @Test
+    void getAllBillingsNotFoundEmpty(){
+        when(billServiceClient.getAllBilling()).thenReturn(Flux.empty());
+
+        client.get()
+                //check the URI
+                .uri("/api/gateway/bills")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$[0].billId").doesNotExist();
+    }
 }


### PR DESCRIPTION
[JIRA: link to jira ticket](https://champlainsaintlambert.atlassian.net/jira/software/c/projects/PCI/boards/38?modal=detail&selectedIssue=PCI-48)
## Context:
Improve coverage of Billing Api-Gateway Testing
## Changes
Added missing Controller tests for get All bills and get all bills empty.
Added missing tests for billing service client.
Modified BillDetails by removing the @Data so it doesn't have uncovered autogenerated methods. It uses @Setter, @Getter and @NoArgsConstructor instead.
## Before and After UI (Required for UI-impacting PRs)
No UI Change
## Proofs
<img width="434" alt="BillDetails" src="https://user-images.githubusercontent.com/39575197/194738556-83ade2f8-d99b-46ba-8d14-513ffcc2b77b.png">
<img width="542" alt="BillServiceClient100" src="https://user-images.githubusercontent.com/39575197/194738557-b18a0de0-056d-4b80-bed0-90a52d27a9e0.png">
<img width="960" alt="JacocoController" src="https://user-images.githubusercontent.com/39575197/194738558-b12f9f90-68f4-4df6-b35e-49956e70a18e.png">
<img width="535" alt="Selenium" src="https://user-images.githubusercontent.com/39575197/194738559-0c68382e-045d-4832-a9e7-c9e4c371c506.png">
